### PR TITLE
Migration to enterprise server

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -1,2 +1,2 @@
 ingresses:
-  - "https://formio-enterprise-server.dev.nav.no"
+  - "https://formio-api-server.ekstern.dev.nav.no"

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     nais.io/run-as-user: "5000"
     nais.io/run-as-group: "5000"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50M"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:
   image: {{image}}
   port: 3000


### PR DESCRIPTION
Use same ingress as current api server, and add proxy-body-size and proxy-read-timeout annotations.